### PR TITLE
Add some doc to README and format it according to markdownlint rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,25 @@
 # Release-tracking repository for nlohmann/json
 
-This repository is based on: [astoeckel/json](https://github.com/astoeckel/json).
-The goal is to provide a lightweight repository tracking every releases of
-[nlohmann/json](https://github.com/nlohmann/json), compatible with cmake [FetchContent](https://cmake.org/cmake/help/v3.11/module/FetchContent.html).
+Goal is to provide a lightweight and autonomous repository tracking every
+releases of [nlohmann/json](https://github.com/nlohmann/json).
 
-You can depends on it using:
+It is meant to be used with CMake
+[FetchContent](https://cmake.org/cmake/help/v3.11/module/FetchContent.html).
 
-**Example**:
+You can always replace the URL by the official repository:
+<https://github.com/nlohmann/json>.
+The only differences are:
+
+* The download size: ~500KB vs ~150MB (300× difference)
+* Some options are not available. See [the unsupported options section](#Unsupported-options).
+
+## Example
+
 ~~~cmake
 include(FetchContent)
+
+# Optional: set this to ON if your target publicly links to nlohmann_json and needs to install() 
+# set(JSON_Install ON)
 
 FetchContent_Declare(json
   GIT_REPOSITORY https://github.com/ArthurSonzogni/nlohmann_json_cmake_fetchcontent
@@ -16,27 +27,36 @@ FetchContent_Declare(json
   GIT_SHALLOW TRUE
   GIT_TAG v3.10.5)
 
-FetchContent_GetProperties(json)
-if(NOT json_POPULATED)
-  FetchContent_Populate(json)
-  add_subdirectory(${json_SOURCE_DIR} ${json_BINARY_DIR} EXCLUDE_FROM_ALL)
-endif()
+FetchContent_MakeAvailable(json)
 
 target_link_libraries(foo PRIVATE nlohmann_json::nlohmann_json)
 ~~~
 
-You can replace always replace the URL by the official repository:
-https://github.com/nlohmann/json
-The only difference is the download size. It would be several orders of magnitude
-larger.
+## Unsupported options
+
+The following options are currently not supported. This is done on purpose
+because they do not really make sense for a mirror repository, or they have not
+been thoroughly tested. Consider using the official repository if you need these
+options.
+
+* `JSON_CI`
+* `JSON_BuildTests`
+
+## Updates
 
 This repository is fully autonomous. It updates itself every week using github
 actions.
 
-See:
-- [#2073](https://github.com/nlohmann/json/issues/2073),
-- [#732](https://github.com/nlohmann/json/issues/732),
-- [#620](https://github.com/nlohmann/json/issues/620),
-- [#556](https://github.com/nlohmann/json/issues/556),
-- [#482](https://github.com/nlohmann/json/issues/482),
-- [#96](https://github.com/nlohmann/json/issues/96)
+### Thanks
+
+This repository is based on: [astoeckel/json](https://github.com/astoeckel/json).
+
+### Addressed `nlohmann/json` issues:
+
+* [#2073](https://github.com/nlohmann/json/issues/2073),
+* [#732](https://github.com/nlohmann/json/issues/732),
+* [#620](https://github.com/nlohmann/json/issues/620),
+* [#556](https://github.com/nlohmann/json/issues/556),
+* [#482](https://github.com/nlohmann/json/issues/482),
+* [#96](https://github.com/nlohmann/json/issues/96)
+


### PR DESCRIPTION
This is pretty minor so opening another PR feels a bit overkill but is there any reason for not using FetchContent_MakeAvailable (i.e. in the README)? This seems like the recommended approach. See [the CMake docs about FetchContent](https://cmake.org/cmake/help/git-stage/module/FetchContent.html#command:fetchcontent_makeavailable).

I am guessing it is because of the EXCLUDE_FROM_ALL property, which is a bit more intricate to use with Fetchcontent_MakeAvailable (see https://gitlab.kitware.com/cmake/cmake/-/issues/20167). Is this problematic?

EDIT: I got a bit carried away and rewrote some parts of the README. I think it is more explicit now, but this is very subjective and I'd understand if you prefer the previous one :-)